### PR TITLE
Fix: Add validation to prevent silent user name truncation

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -17,7 +17,7 @@ export const usersRoute = new Elysia()
     }
   }, {
     body: t.Object({
-      name: t.String(),
+      name: t.String({ maxLength: 255 }),
       email: t.String(),
       password: t.String(),
     })


### PR DESCRIPTION
This PR adds maxLength validation to the registration route to prevent names longer than 255 characters from being silently truncated by the database. Closes #11